### PR TITLE
Fix GPT call history handling

### DIFF
--- a/backend/gptcall/services.py
+++ b/backend/gptcall/services.py
@@ -8,26 +8,46 @@ class GPTService:
         self.client = openai_client or OpenAI(api_key=settings.OPENAI_API_KEY)
 
     def create_gpt_call(self, history: list = None):
+        history = history or []
+
         if len(history) == 0:
             history = [
-                {"role": "system", "content": "You are an inquisitive and mysterious person. You only give conversational responses, not verbose ones."},
+                {
+                    "role": "system",
+                    "content": (
+                        "You are an inquisitive and mysterious person. "
+                        "You only give conversational responses, not verbose ones."
+                    ),
+                },
                 {"role": "user", "content": "Ask me a random question about my past."},
             ]
 
-        GptCall.objects.create(role="user", content=history[len(history) - 1], refusal=None)
+        last_message = history[-1]
+        GptCall.objects.create(
+            role=last_message.get("role"),
+            content=last_message.get("content"),
+            refusal=last_message.get("refusal"),
+        )
 
         response = self.client.chat.completions.create(
             model="gpt-4o-mini",
             messages=history,
         )
 
-        history.append({
-            "role": response.choices[0].message.role,
-            "content": response.choices[0].message.content,
-            "refusal": response.choices[0].message.refusal
-        })
+        history.append(
+            {
+                "role": response.choices[0].message.role,
+                "content": response.choices[0].message.content,
+                "refusal": response.choices[0].message.refusal,
+            }
+        )
 
-        GptCall.objects.create(role="assistant", content=history[len(history) - 1], refusal=None)
+        last_message = history[-1]
+        GptCall.objects.create(
+            role=last_message.get("role"),
+            content=last_message.get("content"),
+            refusal=last_message.get("refusal"),
+        )
 
         print(response.to_json())
 


### PR DESCRIPTION
## Summary
- gracefully handle None or empty history lists
- record only the message content when creating `GptCall` entries

## Testing
- `python -m py_compile backend/gptcall/services.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_683f5886a84c832eba220b95610265ba