### PR TITLE
Fix Linux setup typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ OPENAI_API_KEY=your_api_key
 
 These Linux installation instructions aren't as thorough as the Windows instructions because they assume that if you are running Linux, you are familiar with dependencies and package management.
 
-To intialize the python application on Linux, cd to the root directory of the project and run
+To initialize the python application on Linux, cd to the root directory of the project and run
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate


### PR DESCRIPTION
## Summary
- correct typo `intialize` -> `initialize` in Linux setup instructions

## Testing
- `pytest -q`
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_e_683f58890880832e8375d33caf181901